### PR TITLE
Potential fix for code scanning alert no. 2: Code injection

### DIFF
--- a/.github/workflows/libcxx-run-benchmarks.yml
+++ b/.github/workflows/libcxx-run-benchmarks.yml
@@ -64,17 +64,21 @@ jobs:
           path: repo # Avoid nuking the workspace, where we have the Python virtualenv
 
       - name: Run baseline
+        env:
+          BENCHMARKS: ${{ steps.vars.outputs.benchmarks }}
         run: |
           source .venv/bin/activate && cd repo
           python -m pip install -r libcxx/utils/requirements.txt
           baseline_commit=$(git merge-base ${{ steps.vars.outputs.pr_base }} ${{ steps.vars.outputs.pr_head }})
-          ./libcxx/utils/test-at-commit --commit ${baseline_commit} -B build/baseline -- -sv -j1 --param optimization=speed ${{ steps.vars.outputs.benchmarks }}
+          ./libcxx/utils/test-at-commit --commit ${baseline_commit} -B build/baseline -- -sv -j1 --param optimization=speed $BENCHMARKS
           ./libcxx/utils/consolidate-benchmarks build/baseline | tee baseline.lnt
 
       - name: Run candidate
+        env:
+          BENCHMARKS: ${{ steps.vars.outputs.benchmarks }}
         run: |
           source .venv/bin/activate && cd repo
-          ./libcxx/utils/test-at-commit --commit ${{ steps.vars.outputs.pr_head }} -B build/candidate -- -sv -j1 --param optimization=speed ${{ steps.vars.outputs.benchmarks }}
+          ./libcxx/utils/test-at-commit --commit ${{ steps.vars.outputs.pr_head }} -B build/candidate -- -sv -j1 --param optimization=speed $BENCHMARKS
           ./libcxx/utils/consolidate-benchmarks build/candidate | tee candidate.lnt
 
       - name: Compare baseline and candidate runs


### PR DESCRIPTION
Potential fix for [https://github.com/aka76bm/llvm-project/security/code-scanning/2](https://github.com/aka76bm/llvm-project/security/code-scanning/2)

To fix the code injection vulnerability, we must ensure that the untrusted user input (`benchmarks`) is not directly inserted into the shell command via `${{ ... }}` interpolation, but instead is passed as an environment variable and referenced using shell-native syntax (`$BENCHMARKS`). In particular, in the relevant workflow steps (at least lines 71 and 77), we should replace `${{ steps.vars.outputs.benchmarks }}` with `$BENCHMARKS`. To implement this securely, we must set an environment variable named `BENCHMARKS` from `steps.vars.outputs.benchmarks` for any job step that uses it (i.e., add `env:` for those steps) and update the shell command to reference `$BENCHMARKS`. No new imports or dependencies are needed, just safer usage of existing expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
